### PR TITLE
Add pipeline status endpoint to retrieve run summaries

### DIFF
--- a/modules/api/app.py
+++ b/modules/api/app.py
@@ -5,6 +5,8 @@ from .routes.entities import router as entities_router
 app = FastAPI(title="Opsight API", version="0.1")
 app.include_router(ingest_router)
 app.include_router(entities_router)
+from .routes.status import router as status_router
+app.include_router(status_router)
 
 @app.get("/health")
 def health():

--- a/modules/api/routes/status.py
+++ b/modules/api/routes/status.py
@@ -1,0 +1,19 @@
+# modules/api/routes/status.py
+import json
+from pathlib import Path
+from fastapi import APIRouter
+
+router = APIRouter()
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SUMMARY_PATH = PROJECT_ROOT / "reports" / "pipeline_run_summary.json"
+
+@router.get("/pipeline/status")
+def get_pipeline_status():
+    if not SUMMARY_PATH.exists():
+        return {"status": "no runs recorded"}
+
+    with open(SUMMARY_PATH, "r") as f:
+        summary = json.load(f)
+
+    return summary


### PR DESCRIPTION
Introduce an endpoint to fetch the status of pipeline runs, returning summaries from a specified JSON file.