### PR TITLE
Add entity record explorer view to Opsight UI

### DIFF
--- a/modules/ui/app.py
+++ b/modules/ui/app.py
@@ -8,6 +8,7 @@ if str(PROJECT_ROOT) not in sys.path:
 import streamlit as st
 from modules.ui.views.upload import render_upload_view
 from modules.ui.views.metrics import render_metrics_view
+from modules.ui.views.entity_explorer import render_entity_explorer
 
 st.set_page_config(page_title="Opsight UI", layout="wide")
 
@@ -27,3 +28,4 @@ st.info("Placeholder UI loaded successfully. Dashboard views will be added next.
 
 render_upload_view()
 render_metrics_view()
+render_entity_explorer()

--- a/modules/ui/views/entity_explorer.py
+++ b/modules/ui/views/entity_explorer.py
@@ -1,0 +1,51 @@
+import requests
+import streamlit as st
+import pandas as pd
+
+
+def render_entity_explorer():
+    st.subheader("Entity Record Explorer")
+
+    entity_id = st.text_input("Enter entity_id")
+
+    if not entity_id:
+        return
+
+    try:
+        response = requests.get(f"http://127.0.0.1:8000/entity/{entity_id}")
+
+        if response.status_code == 404:
+            st.info("No records found for that entity_id.")
+            return
+
+        if response.status_code != 200:
+            st.error("Failed to retrieve entity records.")
+            return
+
+        payload = response.json()
+        records = payload.get("records", [])
+
+        if not records:
+            st.info("No records found for that entity_id.")
+            return
+
+        st.write(f"Found {len(records)} record(s) for entity_id {entity_id}")
+
+        flat_rows = []
+        for record in records:
+            row = {
+                "entity_id": record.get("entity_id"),
+                "timestamp": record.get("timestamp"),
+                **record.get("features", {}),
+                **{f"meta_{k}": v for k, v in record.get("metadata", {}).items()},
+            }
+            flat_rows.append(row)
+
+        df = pd.DataFrame(flat_rows)
+        st.dataframe(df, use_container_width=True)
+
+        st.write("### Raw Records")
+        st.json(records)
+
+    except Exception as exc:
+        st.error(f"Failed to connect to API: {exc}")


### PR DESCRIPTION
Introduce an entity record explorer view that allows users to input an entity ID and retrieve associated records from the API. This feature enhances the UI by providing a dedicated section for exploring entity data.