### PR TITLE
Update CI pipeline to use pytest and adjust Python version

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,27 +1,27 @@
-name: Run Pipeline
+name: CI
 
 on:
   push:
-    branches: ["main"]
-  workflow_dispatch:
+    branches: [main]
+  pull_request:
 
 jobs:
-  run-pipeline:
+  test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Run tests
-        run: python -m unittest discover -s tests
-
-      - name: Run pipeline
-        run: python run_pipeline.py
+        run: python -m pytest


### PR DESCRIPTION
Modify the CI pipeline configuration to utilize pytest for testing and change the Python version from 3.12 to 3.11.