### PR TITLE
Enhance data contract documentation with validation examples

### DIFF
--- a/modules/adapter/data_contract.md
+++ b/modules/adapter/data_contract.md
@@ -12,13 +12,14 @@ The adapter receives a loaded dataset and produces a normalized internal represe
 
 Structure:
 
-
+```python
 record = {
-"entity_id_cols": [str],
-"timestamp_cols": [str],
-"feature_cols": [str],
-"data": pandas.DataFrame
+	"entity_id_cols": [str],
+	"timestamp_cols": [str],
+	"feature_cols": [str],
+	"data": pandas.DataFrame,
 }
+```
 
 
 ### Field Descriptions
@@ -28,7 +29,9 @@ List of columns representing entity identifiers.
 
 Example:
 
+```python
 ["customer_id"]
+```
 
 
 **timestamp_cols**  
@@ -36,7 +39,9 @@ List of columns representing timestamps or event times.
 
 Example:
 
+```python
 ["created_at"]
+```
 
 
 **feature_cols**  
@@ -44,7 +49,9 @@ Columns representing measurable attributes or features of the record.
 
 Example:
 
+```python
 ["amount", "region", "product"]
+```
 
 
 **data**  
@@ -52,10 +59,11 @@ A pandas DataFrame containing the dataset rows.
 
 Example:
 
-
+```text
 customer_id | created_at | amount | region
 101 | 2026-03-12 | 45.00 | west
 102 | 2026-03-13 | 51.00 | east
+```
 
 
 ---
@@ -66,15 +74,16 @@ The adapter returns a list of canonical records.
 
 Structure:
 
-
+```python
 [
-{
-"entity_id": Any,
-"timestamp": Any,
-"features": dict,
-"metadata": dict
-}
+	{
+		"entity_id": Any,
+		"timestamp": Any,
+		"features": dict,
+		"metadata": dict,
+	}
 ]
+```
 
 
 ### Field Descriptions
@@ -84,7 +93,9 @@ The identifier for the entity associated with the record.
 
 Example:
 
+```text
 101
+```
 
 
 **timestamp**  
@@ -92,7 +103,9 @@ The time associated with the event or record.
 
 Example:
 
+```text
 "2026-03-12"
+```
 
 
 **features**  
@@ -100,11 +113,12 @@ Dictionary containing feature values extracted from the dataset.
 
 Example:
 
-
+```json
 {
-"amount": 45.00,
-"region": "west"
+	"amount": 45.0,
+	"region": "west"
 }
+```
 
 
 **metadata**  
@@ -112,10 +126,11 @@ Optional information describing the record source or processing details.
 
 Example:
 
-
+```json
 {
-"source": "orders.csv"
+	"source": "orders.csv"
 }
+```
 
 
 ---
@@ -133,7 +148,7 @@ The adapter guarantees:
 
 ## Pipeline Context
 
-
+```text
 Raw Source
 ↓
 Ingestion (detect and load)
@@ -141,6 +156,7 @@ Ingestion (detect and load)
 Adapter (normalize and map)
 ↓
 Canonical Records
+```
 
 
 The adapter ensures downstream modules always receive standardized records regardless of the original data source.

--- a/modules/validation/data_contract.md
+++ b/modules/validation/data_contract.md
@@ -25,11 +25,18 @@ errors
     A list of validation error messages.
     Empty if the record is valid.
 
+Example valid result:
+
+```json
 {
   "status": "valid",
   "errors": []
 }
+```
 
+Example invalid result:
+
+```json
 {
   "status": "invalid",
   "errors": [
@@ -37,6 +44,7 @@ errors
       "Features must be a dictionary"
   ]
 }
+```
 
 `errors` may include:
 


### PR DESCRIPTION
Improve the documentation by adding examples for validation results, clarifying the expected structure and content for both valid and invalid records.