### PR TITLE
Fix CMD instruction in Dockerfile for consistent port usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN mkdir -p logs reports
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "uvicorn modules.api.app:app --host 0.0.0.0 --port ${PORT}"]
+CMD ["uvicorn", "modules.api.app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Update the CMD instruction in the Dockerfile to use a fixed port for consistency, enhancing the reliability of the application deployment.