### PR TITLE
Implement Metrics tab and integrate pipeline result display

### DIFF
--- a/modules/frontend/src/App.jsx
+++ b/modules/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { getHealth } from "./api/client";
 import UploadTab from "./tabs/UploadTab";
+import MetricsTab from "./tabs/MetricsTab";
 
 const tabs = [
   { id: "upload", label: "Upload" },
@@ -14,6 +15,7 @@ export default function App() {
   const [healthStatus, setHealthStatus] = useState("Checking API...");
   const [healthError, setHealthError] = useState("");
   const [apiVersion, setApiVersion] = useState("");
+  const [pipelineResult, setPipelineResult] = useState(null);
 
   useEffect(() => {
     async function checkApi() {
@@ -35,15 +37,9 @@ export default function App() {
   const renderPanel = () => {
     switch (activeTab) {
       case "upload":
-        return <UploadTab />;
+        return <UploadTab onPipelineComplete={setPipelineResult} />;
       case "metrics":
-        return (
-          <>
-            <h2>Metrics</h2>
-            <p>Summary metrics and KPI views will appear here.</p>
-            <p>Connected metrics UI will be added in PS-120.</p>
-          </>
-        );
+        return <MetricsTab pipelineResult={pipelineResult} />;
       case "charts":
         return (
           <>

--- a/modules/frontend/src/tabs/MetricsTab.jsx
+++ b/modules/frontend/src/tabs/MetricsTab.jsx
@@ -1,0 +1,39 @@
+export default function MetricsTab({ pipelineResult }) {
+  if (!pipelineResult) {
+    return (
+      <div>
+        <h2>Pipeline Metrics</h2>
+        <p>No data yet. Run the pipeline from the Upload tab.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Pipeline Metrics</h2>
+
+      <div style={{ display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))" }}>
+        <MetricCard label="Ingested" value={pipelineResult.records_ingested} />
+        <MetricCard label="Valid" value={pipelineResult.records_valid} />
+        <MetricCard label="Invalid" value={pipelineResult.records_invalid} />
+        <MetricCard label="Persisted" value={pipelineResult.records_persisted} />
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({ label, value }) {
+  return (
+    <div
+      style={{
+        border: "1px solid #ccc",
+        borderRadius: "10px",
+        padding: "1rem",
+        textAlign: "center",
+      }}
+    >
+      <div style={{ fontSize: "0.9rem", opacity: 0.7 }}>{label}</div>
+      <div style={{ fontSize: "1.5rem", fontWeight: 700 }}>{value ?? 0}</div>
+    </div>
+  );
+}

--- a/modules/frontend/src/tabs/UploadTab.jsx
+++ b/modules/frontend/src/tabs/UploadTab.jsx
@@ -8,7 +8,7 @@ const LOCAL_SAMPLE_SOURCE_PATH = "data/opsight_sample_sales.csv";
 const CLOUD_PROXY_BASE_URL = "/api-cloud";
 const LOCAL_PROXY_BASE_URL = "/api-local";
 
-export default function UploadTab() {
+export default function UploadTab({ onPipelineComplete }) {
   const [accessCode, setAccessCode] = useState("demo-code");
   const [sourcePath, setSourcePath] = useState(BLOB_SAMPLE_SOURCE_PATH);
   const [targetEnvironment, setTargetEnvironment] = useState("cloud");
@@ -52,8 +52,7 @@ export default function UploadTab() {
       baseUrl: requestBaseUrl,
     });
 
-    setLoading(false);
-
+    setLoading(false); 
     if (!response.ok) {
       if (response.status === 401 || response.status === 403) {
         setError("Invalid or missing access code.");
@@ -71,6 +70,9 @@ export default function UploadTab() {
       targetEnvironment === "local" ? "local API" : "deployed API";
     setSuccessMessage(`Pipeline triggered successfully on ${destinationLabel}.`);
     setResult(response.data);
+    if (onPipelineComplete) {
+      onPipelineComplete(response.data);
+    }
   }
 
   return (

--- a/reports/pipeline_run_summary.json
+++ b/reports/pipeline_run_summary.json
@@ -5,5 +5,5 @@
     "records_valid": 3,
     "records_invalid": 0,
     "records_persisted": 3,
-    "runtime_seconds": 0.018513
+    "runtime_seconds": 0.025427
 }


### PR DESCRIPTION
Add a Metrics tab to display pipeline results, enhancing user experience by providing immediate feedback on data processing. The Upload tab now communicates the pipeline results to the Metrics tab upon completion.