### PR TITLE
Issue #261: Add Complete Dataset Summary View

### DIFF
--- a/modules/api/app.py
+++ b/modules/api/app.py
@@ -339,28 +339,95 @@ def charts_overview():
 
     df = pd.DataFrame(rows)
 
+    total_rows = len(df)
+    total_columns = len(df.columns)
+
+    def _round_if_number(value):
+        if pd.isna(value):
+            return None
+        if isinstance(value, (int, float)):
+            return round(float(value), 4)
+        return value
+
     num_cols = [
         c for c in df.columns
         if c != "entity_id" and pd.api.types.is_numeric_dtype(df[c])
     ]
 
+    cat_cols = [
+        c for c in df.columns
+        if c != "entity_id" and not pd.api.types.is_numeric_dtype(df[c])
+    ]
+
+    missing_by_column = {
+        col: int(df[col].isna().sum())
+        for col in df.columns
+    }
+
+    numeric_summary = []
+    for col in num_cols:
+        series = df[col]
+        non_null = series.dropna()
+        numeric_summary.append(
+            {
+                "field": col,
+                "count": int(non_null.count()),
+                "missing": int(series.isna().sum()),
+                "min": _round_if_number(non_null.min()) if len(non_null) > 0 else None,
+                "max": _round_if_number(non_null.max()) if len(non_null) > 0 else None,
+                "mean": _round_if_number(non_null.mean()) if len(non_null) > 0 else None,
+                "median": _round_if_number(non_null.median()) if len(non_null) > 0 else None,
+                "std": _round_if_number(non_null.std()) if len(non_null) > 1 else None,
+            }
+        )
+
+    categorical_summary = []
+    for col in cat_cols:
+        series = df[col]
+        non_null = series.dropna()
+        value_counts = non_null.astype(str).value_counts().head(10)
+        top_values = [
+            {
+                "value": value,
+                "count": int(count),
+            }
+            for value, count in value_counts.items()
+        ]
+        categorical_summary.append(
+            {
+                "field": col,
+                "count": int(non_null.count()),
+                "missing": int(series.isna().sum()),
+                "unique": int(non_null.nunique()),
+                "top_values": top_values,
+            }
+        )
+
     stats: dict = {}
-    if num_cols:
-        series = df[num_cols[0]].dropna()
+    if numeric_summary:
+        first_numeric = numeric_summary[0]
+        series = df[first_numeric["field"]].dropna()
         if len(series) > 0:
             stats = {
-                "min": round(float(series.min()), 4),
-                "max": round(float(series.max()), 4),
-                "mean": round(float(series.mean()), 4),
+                "min": first_numeric["min"],
+                "max": first_numeric["max"],
+                "mean": first_numeric["mean"],
                 "count": int(len(series)),
             }
 
     return {
         "source": source_metadata.get("source_name") or active_dataset,
         "source_metadata": source_metadata,
-        "rows": len(df),
-        "variables": len(df.columns),
+        "rows": total_rows,
+        "variables": total_columns,
+        "shape": {
+            "rows": total_rows,
+            "columns": total_columns,
+        },
         "fields": list(df.columns),
+        "missing_by_column": missing_by_column,
+        "numeric_summary": numeric_summary,
+        "categorical_summary": categorical_summary,
         "chart_context": _build_chart_context(df),
         **stats,
     }

--- a/modules/frontend/src/tabs/ChartsTab.jsx
+++ b/modules/frontend/src/tabs/ChartsTab.jsx
@@ -11,6 +11,18 @@ import {
 import { chartCatalog } from "../catalog/chartCatalog";
 import { resolveBaseUrl } from "../config/env";
 
+function downloadJson(filename, payload) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(objectUrl);
+}
+
 export default function ChartsTab({ activeDatasetId = null }) {
   const isDev = import.meta.env.DEV;
   const [target, setTarget] = useState(isDev ? "local" : "cloud");
@@ -65,6 +77,26 @@ export default function ChartsTab({ activeDatasetId = null }) {
       default:
         return { ok: false, error: "Unsupported chart selection." };
     }
+  };
+
+  const handleExportSummary = () => {
+    if (!overview) {
+      return;
+    }
+
+    const datasetName = overview.source_metadata?.dataset_id || activeDatasetId || "dataset";
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const filename = `${datasetName}-summary-${timestamp}.json`;
+
+    downloadJson(filename, {
+      source: overview.source,
+      source_metadata: overview.source_metadata,
+      shape: overview.shape,
+      fields: overview.fields,
+      missing_by_column: overview.missing_by_column,
+      numeric_summary: overview.numeric_summary,
+      categorical_summary: overview.categorical_summary,
+    });
   };
 
   const handleChartSelect = async (chartId) => {
@@ -200,11 +232,97 @@ const getChartContextEntries = (overview, chartId) => {
           {overview.variables != null && <p>Variables: {overview.variables}</p>}
           {overview.fields && <p>Fields: {overview.fields.join(", ")}</p>}
 
+          {overview.shape ? (
+            <p>
+              Shape: {overview.shape.rows} x {overview.shape.columns}
+            </p>
+          ) : null}
+
+          <button
+            type="button"
+            onClick={handleExportSummary}
+            style={{
+              marginTop: "0.5rem",
+              marginBottom: "0.5rem",
+              padding: "0.45rem 0.8rem",
+              borderRadius: "6px",
+              border: "1px solid #ccc",
+              cursor: "pointer",
+              fontSize: "0.85rem",
+              fontWeight: 600,
+            }}
+          >
+            Export Summary (JSON)
+          </button>
+
           <h3>Summary Statistics</h3>
           {overview.min != null && <p>Min: {overview.min}</p>}
           {overview.max != null && <p>Max: {overview.max}</p>}
           {overview.mean != null && <p>Mean: {overview.mean}</p>}
           {overview.count != null && <p>Count: {overview.count}</p>}
+
+          <h3>Missing Values By Column</h3>
+          {overview.missing_by_column ? (
+            <div>
+              {Object.entries(overview.missing_by_column).map(([field, missing]) => (
+                <p key={`missing-${field}`}>
+                  {field}: {missing}
+                </p>
+              ))}
+            </div>
+          ) : (
+            <p>No missing-value summary available.</p>
+          )}
+
+          <h3>Numeric Field Summary</h3>
+          {overview.numeric_summary?.length ? (
+            <div>
+              {overview.numeric_summary.map((item) => (
+                <div
+                  key={`numeric-${item.field}`}
+                  style={{ marginBottom: "0.65rem", paddingBottom: "0.65rem", borderBottom: "1px solid #eee" }}
+                >
+                  <p><strong>{item.field}</strong></p>
+                  <p>Count: {item.count} | Missing: {item.missing}</p>
+                  <p>
+                    Min: {item.min ?? "N/A"} | Max: {item.max ?? "N/A"} | Mean: {item.mean ?? "N/A"}
+                  </p>
+                  <p>
+                    Median: {item.median ?? "N/A"} | Std Dev: {item.std ?? "N/A"}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p>No numeric summary available.</p>
+          )}
+
+          <h3>Categorical Frequency Summary</h3>
+          {overview.categorical_summary?.length ? (
+            <div>
+              {overview.categorical_summary.map((item) => (
+                <div
+                  key={`categorical-${item.field}`}
+                  style={{ marginBottom: "0.65rem", paddingBottom: "0.65rem", borderBottom: "1px solid #eee" }}
+                >
+                  <p>
+                    <strong>{item.field}</strong> (Unique: {item.unique}, Missing: {item.missing})
+                  </p>
+                  {item.top_values?.length ? (
+                    item.top_values.map((entry, index) => (
+                      <p key={`cat-${item.field}-${entry.value}-${index}`}>
+                        {entry.value}: {entry.count}
+                      </p>
+                    ))
+                  ) : (
+                    <p>No frequency data available.</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p>No categorical summary available.</p>
+          )}
         </>
       ) : null}
 

--- a/modules/frontend/src/tabs/ChartsTab.test.jsx
+++ b/modules/frontend/src/tabs/ChartsTab.test.jsx
@@ -51,7 +51,37 @@ describe("ChartsTab", () => {
         },
         rows: 10,
         variables: 3,
+        shape: { rows: 10, columns: 3 },
         fields: ["entity_id", "metric_value", "category"],
+        missing_by_column: {
+          entity_id: 0,
+          metric_value: 1,
+          category: 2,
+        },
+        numeric_summary: [
+          {
+            field: "metric_value",
+            count: 9,
+            missing: 1,
+            min: 1,
+            max: 20,
+            mean: 10,
+            median: 9,
+            std: 3.5,
+          },
+        ],
+        categorical_summary: [
+          {
+            field: "category",
+            count: 8,
+            missing: 2,
+            unique: 2,
+            top_values: [
+              { value: "Furniture", count: 5 },
+              { value: "Office Supplies", count: 3 },
+            ],
+          },
+        ],
       },
     });
   });
@@ -166,5 +196,47 @@ describe("ChartsTab", () => {
     expect(await screen.findByText("Source: Superstore Sales Dataset")).toBeInTheDocument();
     expect(screen.getByText("Source Location: opsight-raw/csv/Sample - Superstore.csv")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "https://www.kaggle.com/datasets/vivek468/superstore-dataset-final" })).toBeInTheDocument();
+    expect(screen.getByText("Shape: 10 x 3")).toBeInTheDocument();
+    expect(screen.getByText("entity_id: 0")).toBeInTheDocument();
+    expect(screen.getByText("metric_value: 1")).toBeInTheDocument();
+    expect(screen.getByText("category: 2")).toBeInTheDocument();
+    expect(screen.getByText("Furniture: 5")).toBeInTheDocument();
+    expect(screen.getByText("Office Supplies: 3")).toBeInTheDocument();
+  });
+
+  it("exports summary as json when export button is clicked", async () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
+    URL.createObjectURL = vi.fn(() => "blob:summary");
+    URL.revokeObjectURL = vi.fn(() => {});
+
+    const appendSpy = vi.spyOn(document.body, "appendChild");
+    const removeSpy = vi.spyOn(document.body, "removeChild");
+
+    const originalCreateElement = document.createElement.bind(document);
+    const clickSpy = vi.fn();
+    const createElementSpy = vi.spyOn(document, "createElement").mockImplementation((tagName) => {
+      const element = originalCreateElement(tagName);
+      if (String(tagName).toLowerCase() === "a") {
+        element.click = clickSpy;
+      }
+      return element;
+    });
+
+    render(<ChartsTab activeDatasetId="sales_csv" />);
+
+    const exportButton = await screen.findByRole("button", { name: "Export Summary (JSON)" });
+    fireEvent.click(exportButton);
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(appendSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:summary");
+
+    createElementSpy.mockRestore();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
   });
 });

--- a/reports/pipeline_run_summary.json
+++ b/reports/pipeline_run_summary.json
@@ -7,5 +7,5 @@
     "records_valid": 9994,
     "records_invalid": 0,
     "records_persisted": 9994,
-    "runtime_seconds": 2.69445
+    "runtime_seconds": 2.587536
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -602,6 +602,63 @@ class TestApiLayer(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {"status": "no runs recorded"})
 
+    def test_charts_overview_returns_complete_dataset_summary(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            storage_path = Path(tmp_dir) / "records.json"
+            local_storage = LocalStorage(storage_path=str(storage_path))
+            local_storage.save_records(
+                [
+                    {
+                        "entity_id": "1",
+                        "timestamp": "2026-01-01",
+                        "features": {"sales": 100.0, "profit": 20.0, "category": "Furniture"},
+                        "metadata": {},
+                    },
+                    {
+                        "entity_id": "2",
+                        "timestamp": "2026-01-02",
+                        "features": {"sales": 200.0, "profit": None, "category": "Office Supplies"},
+                        "metadata": {},
+                    },
+                    {
+                        "entity_id": "3",
+                        "timestamp": "2026-01-03",
+                        "features": {"sales": None, "profit": 15.0, "category": "Furniture"},
+                        "metadata": {},
+                    },
+                ]
+            )
+
+            session_state.set_active_dataset("sales_csv")
+            session_state.set_dataset_source_metadata(
+                {
+                    "dataset_id": "sales_csv",
+                    "source_type": "blob",
+                    "source_name": "Superstore Sales Dataset",
+                    "source_url": "https://www.kaggle.com/datasets/vivek468/superstore-dataset-final",
+                    "source_location": "opsight-raw/csv/Sample - Superstore.csv",
+                }
+            )
+
+            with patch("modules.api.app.StorageConfig") as mocked_storage_config:
+                mocked_storage_config.return_value.storage_path = str(storage_path)
+                response = self.client.get("/charts/overview")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["shape"], {"rows": 3, "columns": 4})
+        self.assertEqual(body["source"], "Superstore Sales Dataset")
+        self.assertEqual(body["missing_by_column"]["sales"], 1)
+        self.assertEqual(body["missing_by_column"]["profit"], 1)
+
+        numeric_fields = {item["field"] for item in body["numeric_summary"]}
+        self.assertIn("sales", numeric_fields)
+        self.assertIn("profit", numeric_fields)
+
+        categorical = next(item for item in body["categorical_summary"] if item["field"] == "category")
+        self.assertEqual(categorical["unique"], 2)
+        self.assertEqual(categorical["top_values"][0]["value"], "Furniture")
+
     def test_kmeans_anomaly_endpoint_returns_summary_from_persisted_records(self):
         mocked_records = [
             {"entity_id": "1", "timestamp": "2026-03-01", "value": 10.0},


### PR DESCRIPTION
Summary
- Adds a complete dataset summary view in Charts to satisfy assignment overall-summary requirements.
- Extends API overview response with shape, missing values, numeric summaries, and categorical frequency summaries.
- Adds JSON export for summary evidence.

What changed
- Expanded /charts/overview payload with export-ready summary fields.
- Updated Charts UI to render complete summary sections.
- Added Export Summary (JSON) action.
- Updated frontend and backend tests for summary and export coverage.

Validation
- Frontend targeted tests passed:
  - ChartsTab
- Backend targeted tests passed:
  - test_charts_overview_returns_complete_dataset_summary

Issue
- Closes #261