### PR TITLE
Add Guided Relationship Analysis (#264)

### DIFF
--- a/modules/api/app.py
+++ b/modules/api/app.py
@@ -25,6 +25,8 @@ from modules.visualization.plots import (
     create_boxplot,
     create_scatter_plot,
     create_grouped_comparison_chart,
+    create_grouped_boxplot_chart,
+    create_time_line_chart,
 )
 from modules.ingestion.ingestion import ingest_data
 from modules.adapter.adapter import adapt_records
@@ -211,6 +213,14 @@ def _build_chart_context(df: pd.DataFrame, compare_variable: str = "Profit") -> 
         "grouped-comparison": {
             "target_variable": target_label,
             "compare_variable": compare_label,
+        },
+        "grouped-boxplot": {
+            "target_variable": target_label,
+            "compare_variable": compare_label,
+        },
+        "time-line": {
+            "target_variable": target_label,
+            "compare_variable": "Order Date" if "Order Date" in resolved_fields else None,
         },
     }
 
@@ -477,6 +487,67 @@ def grouped_comparison(
         raise
     except Exception as exc:
         logger.error(f"Grouped comparison chart generation failed: {str(exc)}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.get("/charts/grouped-boxplot")
+def grouped_boxplot(
+    target_variable: str = ASSIGNMENT_TARGET_VARIABLE,
+    compare_variable: str = "Category",
+):
+    try:
+        df = get_chart_dataframe()
+        target_column, compare_column, _, target_label, compare_label = _resolve_chart_columns(
+            df,
+            target_variable=target_variable,
+            compare_variable=compare_variable,
+        )
+        path = create_grouped_boxplot_chart(
+            df,
+            target_column=target_column,
+            compare_column=compare_column,
+            target_label=target_label,
+            compare_label=compare_label,
+        )
+        return {"image": path}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Grouped box plot generation failed: {str(exc)}")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@app.get("/charts/time-line")
+def time_line_chart(
+    target_variable: str = ASSIGNMENT_TARGET_VARIABLE,
+    compare_variable: str = "Order Date",
+):
+    try:
+        df = get_chart_dataframe()
+        target_column, compare_column, _, target_label, compare_label = _resolve_chart_columns(
+            df,
+            target_variable=target_variable,
+            compare_variable=compare_variable,
+        )
+
+        if compare_label != "Order Date":
+            raise HTTPException(
+                status_code=422,
+                detail="Time line chart requires compare variable 'Order Date'.",
+            )
+
+        path = create_time_line_chart(
+            df,
+            target_column=target_column,
+            compare_column=compare_column,
+            target_label=target_label,
+            compare_label=compare_label,
+        )
+        return {"image": path}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Time line chart generation failed: {str(exc)}")
         raise HTTPException(status_code=500, detail=str(exc))
 
 

--- a/modules/frontend/src/api/client.js
+++ b/modules/frontend/src/api/client.js
@@ -150,6 +150,28 @@ export async function getGroupedComparison({ baseUrl, targetVariable, compareVar
     baseUrl,
   );
 }
+
+export async function getGroupedBoxplot({ baseUrl, targetVariable, compareVariable } = {}) {
+  return request(
+    buildChartPath("/charts/grouped-boxplot", {
+      target_variable: targetVariable,
+      compare_variable: compareVariable,
+    }),
+    { method: "GET" },
+    baseUrl,
+  );
+}
+
+export async function getTimeLine({ baseUrl, targetVariable, compareVariable } = {}) {
+  return request(
+    buildChartPath("/charts/time-line", {
+      target_variable: targetVariable,
+      compare_variable: compareVariable,
+    }),
+    { method: "GET" },
+    baseUrl,
+  );
+}
 export async function getChartOverview({ baseUrl } = {}) {
   return request(ENDPOINTS.CHARTS_OVERVIEW, { method: "GET" }, baseUrl);
 }

--- a/modules/frontend/src/catalog/chartCatalog.js
+++ b/modules/frontend/src/catalog/chartCatalog.js
@@ -52,4 +52,24 @@ export const chartCatalog = [
       "Recommended because category and metric_value support grouped mean comparison.",
     endpoint: "/charts/grouped-comparison",
   },
+  {
+    id: "grouped-boxplot",
+    title: "Grouped Box Plot",
+    purpose: "Compares distribution spread for a metric across groups.",
+    whenToUse: "Use when you want quartile and outlier comparisons by category.",
+    recommended: true,
+    recommendationReason:
+      "Recommended because grouped box plots are useful for relationship analysis between a metric and group field.",
+    endpoint: "/charts/grouped-boxplot",
+  },
+  {
+    id: "time-line",
+    title: "Time-based Line Chart",
+    purpose: "Shows trend movement of a metric over time.",
+    whenToUse: "Use when a valid date field is available and you need temporal pattern analysis.",
+    recommended: true,
+    recommendationReason:
+      "Recommended when Order Date is available for assignment-aligned time-based relationship analysis.",
+    endpoint: "/charts/time-line",
+  },
 ];

--- a/modules/frontend/src/tabs/ChartsTab.jsx
+++ b/modules/frontend/src/tabs/ChartsTab.jsx
@@ -5,6 +5,8 @@ import {
   getBoxplot,
   getScatter,
   getGroupedComparison,
+  getGroupedBoxplot,
+  getTimeLine,
   getChartOverview,
   getVariableSelection,
   saveVariableSelection,
@@ -79,6 +81,9 @@ export default function ChartsTab({ activeDatasetId = null }) {
   const [overviewError, setOverviewError] = useState("");
   const [targetVariable, setTargetVariable] = useState(DEFAULT_TARGET_VARIABLE);
   const [compareVariables, setCompareVariables] = useState([FALLBACK_COMPARE_OPTIONS[0]]);
+  const [relationshipRuns, setRelationshipRuns] = useState([]);
+  const [relationshipLoading, setRelationshipLoading] = useState(false);
+  const [relationshipError, setRelationshipError] = useState("");
   const selectionLoadedRef = useRef(false);
 
   useEffect(() => {
@@ -267,6 +272,10 @@ export default function ChartsTab({ activeDatasetId = null }) {
         return getScatter({ baseUrl, targetVariable, compareVariable });
       case "grouped-comparison":
         return getGroupedComparison({ baseUrl, targetVariable, compareVariable });
+      case "grouped-boxplot":
+        return getGroupedBoxplot({ baseUrl, targetVariable, compareVariable });
+      case "time-line":
+        return getTimeLine({ baseUrl, targetVariable, compareVariable });
       default:
         return { ok: false, error: "Unsupported chart selection." };
     }
@@ -291,6 +300,14 @@ export default function ChartsTab({ activeDatasetId = null }) {
         compare: compareVariables,
       },
       assignment_analysis: overview.assignment_analysis,
+      relationship_chart_list: relationshipRuns.map((entry) => ({
+        chart_id: entry.chartId,
+        chart_title: entry.chartTitle,
+        target_variable: entry.targetVariable,
+        compare_variable: entry.compareVariable,
+        image: entry.image,
+        generated_at: entry.generatedAt,
+      })),
       missing_by_column: overview.missing_by_column,
       numeric_summary: overview.numeric_summary,
       date_summary: overview.date_summary,
@@ -330,6 +347,63 @@ export default function ChartsTab({ activeDatasetId = null }) {
       ...prev,
       [chartId]: cacheBustedImageUrl,
     }));
+  };
+
+  const handleRunRelationshipAnalysis = async () => {
+    setRelationshipError("");
+    setRelationshipLoading(true);
+
+    const relationshipChartIds = ["scatter", "grouped-boxplot"];
+    const runEntries = [];
+
+    for (const compareVariableCandidate of compareVariables) {
+      const chartIdsForVariable = [...relationshipChartIds];
+      if (normalizeFieldName(compareVariableCandidate) === "order date") {
+        chartIdsForVariable.push("time-line");
+      }
+
+      for (const chartId of chartIdsForVariable) {
+        const baseUrl = resolveBaseUrl(target);
+        let response;
+        if (chartId === "scatter") {
+          response = await getScatter({ baseUrl, targetVariable, compareVariable: compareVariableCandidate });
+        } else if (chartId === "grouped-boxplot") {
+          response = await getGroupedBoxplot({ baseUrl, targetVariable, compareVariable: compareVariableCandidate });
+        } else {
+          response = await getTimeLine({ baseUrl, targetVariable, compareVariable: compareVariableCandidate });
+        }
+
+        if (!response.ok) {
+          setRelationshipLoading(false);
+          setRelationshipError(response.error || "Relationship analysis request failed.");
+          return;
+        }
+
+        const resolvedImageUrl = resolveApiAssetUrl(
+          response.data?.image,
+          baseUrl,
+        );
+
+        if (!resolvedImageUrl) {
+          setRelationshipLoading(false);
+          setRelationshipError("Relationship analysis response did not include an image path.");
+          return;
+        }
+
+        const chartMeta = chartCatalog.find((chart) => chart.id === chartId);
+        runEntries.push({
+          chartId,
+          chartTitle: chartMeta?.title || chartId,
+          targetVariable,
+          compareVariable: compareVariableCandidate,
+          image: `${resolvedImageUrl}${resolvedImageUrl.includes("?") ? "&" : "?"}t=${Date.now()}`,
+          generatedAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    setRelationshipRuns(runEntries);
+    setRelationshipLoading(false);
   };
 
 
@@ -375,6 +449,22 @@ const getChartExplainability = (chartId) => {
         where: "The chart image above is the result.",
       };
 
+    case "grouped-boxplot":
+      return {
+        what: "This chart compares quartiles, spread, and outliers across groups.",
+        time: "Time is not used. Group distributions are compared across the full dataset.",
+        comparison: "It compares per-group distribution shapes for the selected metric.",
+        where: "The chart image above is the result.",
+      };
+
+    case "time-line":
+      return {
+        what: "This chart shows the trend of the selected metric over time.",
+        time: "Time is central. Values are aggregated across date intervals.",
+        comparison: "It compares how the metric changes across time points.",
+        where: "The chart image above is the result.",
+      };
+
     default:
       return {
         what: "No explanation is available for this chart yet.",
@@ -394,6 +484,8 @@ const getChartContextEntries = (chartId, targetVariable, compareVariable) => {
       return [["compare_variable", compareVariable]];
     case "scatter":
     case "grouped-comparison":
+    case "grouped-boxplot":
+    case "time-line":
       return [
         ["target_variable", targetVariable],
         ["compare_variable", compareVariable],
@@ -551,9 +643,11 @@ const getChartContextEntries = (chartId, targetVariable, compareVariable) => {
                 <span style={{ fontSize: "0.78rem", opacity: 0.65 }}>Hold Ctrl / Cmd to select multiple</span>
               </label>
               <div className="summary-variable-cards">
-                {compareVariables.map((cv) =>
-                  renderSummaryCardsForVariable(normalizeFieldName(cv)),
-                )}
+                {compareVariables.map((cv) => (
+                  <React.Fragment key={`summary-${normalizeFieldName(cv)}`}>
+                    {renderSummaryCardsForVariable(normalizeFieldName(cv))}
+                  </React.Fragment>
+                ))}
               </div>
             </div>
           </div>
@@ -563,6 +657,56 @@ const getChartContextEntries = (chartId, targetVariable, compareVariable) => {
       <p style={{ marginBottom: "1rem", opacity: 0.85 }}>
         Each chart includes guidance on what it shows, when to use it, and whether it is recommended for the current dataset.
       </p>
+
+      <h3>Relationship Analysis Mode</h3>
+      <p style={{ marginBottom: "0.5rem", opacity: 0.85 }}>
+        Run scatter, grouped box plot, and time-based line charts in sequence for each selected compare variable.
+      </p>
+      <button
+        type="button"
+        onClick={handleRunRelationshipAnalysis}
+        disabled={!activeDatasetId || overviewLoading || relationshipLoading || compareVariables.length === 0}
+        style={{
+          marginBottom: "0.75rem",
+          padding: "0.45rem 0.85rem",
+          borderRadius: "6px",
+          border: "1px solid #ccc",
+          cursor: "pointer",
+          fontWeight: 600,
+        }}
+      >
+        {relationshipLoading ? "Running Relationship Analysis..." : "Run Guided Relationship Analysis"}
+      </button>
+      {relationshipError ? <p style={{ color: "#c00" }}>{relationshipError}</p> : null}
+      {relationshipRuns.length > 0 ? (
+        <div style={{ marginBottom: "1rem" }}>
+          <p style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
+            Relationship charts generated: {relationshipRuns.length}
+          </p>
+          {relationshipRuns.map((entry, index) => (
+            <div
+              key={`${entry.chartId}-${entry.compareVariable}-${index}`}
+              style={{
+                border: "1px solid #ddd",
+                borderRadius: "8px",
+                padding: "0.75rem",
+                marginBottom: "0.75rem",
+                background: "#fafafa",
+              }}
+            >
+              <p style={{ margin: 0, fontWeight: 700 }}>{entry.chartTitle}</p>
+              <p style={{ margin: "0.35rem 0" }}>
+                <strong>target variable:</strong> {entry.targetVariable} | <strong>compare variable:</strong> {entry.compareVariable}
+              </p>
+              <img
+                src={entry.image}
+                alt={`${entry.chartTitle} relationship visualization`}
+                style={{ maxWidth: "100%", border: "1px solid #ccc", borderRadius: "8px" }}
+              />
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       <div style={{ marginBottom: "1.25rem" }}>
         {isDev && (

--- a/modules/frontend/src/tabs/ChartsTab.test.jsx
+++ b/modules/frontend/src/tabs/ChartsTab.test.jsx
@@ -8,6 +8,8 @@ import {
   getBoxplot,
   getScatter,
   getGroupedComparison,
+  getGroupedBoxplot,
+  getTimeLine,
   getChartOverview,
   getVariableSelection,
   saveVariableSelection,
@@ -20,6 +22,8 @@ vi.mock("../api/client", () => ({
   getBoxplot: vi.fn(),
   getScatter: vi.fn(),
   getGroupedComparison: vi.fn(),
+  getGroupedBoxplot: vi.fn(),
+  getTimeLine: vi.fn(),
   getChartOverview: vi.fn(),
   getVariableSelection: vi.fn(),
   saveVariableSelection: vi.fn(),
@@ -42,6 +46,8 @@ describe("ChartsTab", () => {
     getBoxplot.mockResolvedValue(SUCCESS_RESPONSE("/static/plots/boxplot_metric.png"));
     getScatter.mockResolvedValue(SUCCESS_RESPONSE("/static/plots/scatter_metric_secondary.png"));
     getGroupedComparison.mockResolvedValue(SUCCESS_RESPONSE("/static/plots/grouped_comparison.png"));
+    getGroupedBoxplot.mockResolvedValue(SUCCESS_RESPONSE("/static/plots/grouped_boxplot.png"));
+    getTimeLine.mockResolvedValue(SUCCESS_RESPONSE("/static/plots/time_line.png"));
     getVariableSelection.mockResolvedValue({ ok: false, data: null });
     saveVariableSelection.mockResolvedValue({ ok: true, data: {} });
     getChartOverview.mockResolvedValue({
@@ -569,10 +575,30 @@ describe("ChartsTab", () => {
     expect(payload).toHaveProperty("selected_variables");
     expect(payload.selected_variables).toHaveProperty("target", "Sales");
     expect(Array.isArray(payload.selected_variables.compare)).toBe(true);
+    expect(Array.isArray(payload.relationship_chart_list)).toBe(true);
 
     createElementSpy.mockRestore();
     vi.unstubAllGlobals();
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it("runs relationship analysis in sequence and stores generated chart evidence", async () => {
+    render(<ChartsTab activeDatasetId="sales_csv" />);
+
+    const compareSelect = await screen.findByLabelText("Compare Variable");
+    fireEvent.change(compareSelect, { target: { value: "Order Date" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Run Guided Relationship Analysis" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Relationship charts generated:/)).toBeInTheDocument();
+    });
+
+    expect(getScatter).toHaveBeenCalled();
+    expect(getGroupedBoxplot).toHaveBeenCalled();
+    expect(getTimeLine).toHaveBeenCalledWith(
+      expect.objectContaining({ compareVariable: "Order Date" }),
+    );
   });
 });

--- a/modules/visualization/plots.py
+++ b/modules/visualization/plots.py
@@ -181,3 +181,89 @@ def create_grouped_comparison_chart(
     plt.close(fig)
 
     return f"/static/plots/{filename}"
+
+
+def create_grouped_boxplot_chart(
+    df: pd.DataFrame,
+    target_column,
+    compare_column,
+    target_label: str,
+    compare_label: str,
+) -> str:
+    _ensure_plot_dir()
+    filename = "grouped_boxplot.png"
+    full_path = os.path.join(PLOT_DIR, filename)
+
+    plot_frame = pd.DataFrame(
+        {
+            "target": _get_plot_series(df, target_column, target_label),
+            "compare": _get_plot_series(df, compare_column, compare_label),
+        }
+    ).dropna()
+
+    if plot_frame.empty:
+        raise ValueError("No valid rows available for grouped box plot.")
+
+    grouped_series = []
+    labels = []
+    for category, category_rows in plot_frame.groupby("compare"):
+        values = pd.to_numeric(category_rows["target"], errors="coerce").dropna()
+        if values.empty:
+            continue
+        grouped_series.append(values.values)
+        labels.append(str(category))
+
+    if not grouped_series:
+        raise ValueError("Grouped box plot requires numeric target values.")
+
+    fig, ax = plt.subplots(figsize=(10, 5.5))
+    ax.boxplot(grouped_series)
+    ax.set_title(f"{target_label} Distribution by {compare_label}")
+    ax.set_xlabel(compare_label)
+    ax.set_ylabel(target_label)
+    ax.grid(True, axis="y")
+    _style_category_axis(ax, labels)
+    fig.tight_layout()
+
+    fig.savefig(full_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+
+    return f"/static/plots/{filename}"
+
+
+def create_time_line_chart(
+    df: pd.DataFrame,
+    target_column,
+    compare_column,
+    target_label: str,
+    compare_label: str,
+) -> str:
+    _ensure_plot_dir()
+    filename = "time_line.png"
+    full_path = os.path.join(PLOT_DIR, filename)
+
+    target_series = pd.to_numeric(_get_plot_series(df, target_column, target_label), errors="coerce")
+    compare_series = pd.to_datetime(_get_plot_series(df, compare_column, compare_label), errors="coerce")
+
+    plot_frame = pd.DataFrame({"target": target_series, "compare": compare_series}).dropna()
+    if plot_frame.empty:
+        raise ValueError("Time line chart requires numeric values and a valid date/time field.")
+
+    plot_frame = plot_frame.sort_values("compare")
+    plot_frame = plot_frame.set_index("compare").resample("D")["target"].mean().dropna()
+    if plot_frame.empty:
+        raise ValueError("Time line chart has no plottable points after date aggregation.")
+
+    fig, ax = plt.subplots(figsize=(10, 5.5))
+    ax.plot(plot_frame.index, plot_frame.values, marker="o", linewidth=1.8)
+    ax.set_title(f"{target_label} Trend by {compare_label}")
+    ax.set_xlabel(compare_label)
+    ax.set_ylabel(f"Average {target_label}")
+    ax.grid(True)
+    fig.autofmt_xdate()
+    fig.tight_layout()
+
+    fig.savefig(full_path, dpi=100, bbox_inches="tight")
+    plt.close(fig)
+
+    return f"/static/plots/{filename}"

--- a/tests/test_phase12_charts_api.py
+++ b/tests/test_phase12_charts_api.py
@@ -89,6 +89,14 @@ CHART_ENDPOINTS = {
         "plot_function": "create_grouped_comparison_chart",
         "required_fields": {"sales", "category"},
     },
+    "/charts/grouped-boxplot": {
+        "plot_function": "create_grouped_boxplot_chart",
+        "required_fields": {"sales", "category"},
+    },
+    "/charts/time-line": {
+        "plot_function": "create_time_line_chart",
+        "required_fields": {"sales", "timestamp"},
+    },
 }
 
 
@@ -161,6 +169,12 @@ def test_chart_data_fields_are_consistent_per_chart(monkeypatch):
         response = client.get(endpoint)
         assert response.status_code == 200
         assert response.json()["image"] == "/static/plots/phase12_field_check.png"
+
+
+def test_time_line_requires_order_date_compare_variable():
+    response = client.get("/charts/time-line?compare_variable=Category")
+    assert response.status_code == 422
+    assert "Order Date" in response.json().get("detail", "")
 
 
 def test_chart_generation_performance_and_image_size_are_reasonable():


### PR DESCRIPTION
## Summary
Implements Guided Relationship Analysis for issue #264 across API, visualization, frontend workflow, and automated tests.

## What changed
- Added new chart endpoints for relationship analysis:
  - GET /charts/grouped-boxplot
  - GET /charts/time-line
- Added validation for time-line chart to require compare variable Order Date.
- Added new plot generators:
  - grouped box plot
  - time-based line chart
- Added frontend API client methods for the new endpoints.
- Added dedicated Relationship Analysis Mode in Charts tab:
  - Run Guided Relationship Analysis button
  - Sequential chart generation per selected compare variable
  - Scatter + grouped box plot always
  - Time-based line chart when compare variable is Order Date
  - Display of generated charts with target/compare context
- Extended export payload to include relationship_chart_list evidence.
- Expanded test coverage:
  - Backend chart API tests for new endpoints and time-line validation
  - Frontend Charts tab tests for guided sequence behavior and export evidence

## Validation
- Frontend targeted tests passed (ChartsTab suite)
- Backend targeted tests passed (phase12 charts API suite)
